### PR TITLE
feat(KDP): adding Gated Residual Variable / Features Selection Networ…

### DIFF
--- a/docs/feature_selection.md
+++ b/docs/feature_selection.md
@@ -1,0 +1,160 @@
+# Feature Selection in Keras Data Processor
+
+The Keras Data Processor includes a sophisticated feature selection mechanism based on the Gated Residual Variable Selection Network (GRVSN) architecture. This document explains the components, usage, and benefits of this feature.
+
+## Overview
+
+The feature selection mechanism uses a combination of gated units and residual networks to automatically learn the importance of different features in your data. It can be applied to both numeric and categorical features, either independently or together.
+
+## Components
+
+### 1. GatedLinearUnit
+
+The `GatedLinearUnit` is the basic building block that implements a gated activation function:
+
+```python
+gl = GatedLinearUnit(units=64)
+x = tf.random.normal((32, 100))
+y = gl(x)
+```
+
+Key features:
+- Applies a linear transformation followed by a sigmoid gate
+- Selectively filters input data based on learned weights
+- Helps control information flow through the network
+
+### 2. GatedResidualNetwork
+
+The `GatedResidualNetwork` combines gated linear units with residual connections:
+
+```python
+grn = GatedResidualNetwork(units=64, dropout_rate=0.2)
+x = tf.random.normal((32, 100))
+y = grn(x)
+```
+
+Key features:
+- Uses ELU activation for non-linearity
+- Includes dropout for regularization
+- Adds residual connections to help with gradient flow
+- Applies layer normalization for stability
+
+### 3. VariableSelection
+
+The `VariableSelection` layer is the main feature selection component:
+
+```python
+vs = VariableSelection(nr_features=3, units=64, dropout_rate=0.2)
+x1 = tf.random.normal((32, 100))
+x2 = tf.random.normal((32, 200))
+x3 = tf.random.normal((32, 300))
+selected_features, weights = vs([x1, x2, x3])
+```
+
+Key features:
+- Processes each feature independently using GRNs
+- Calculates feature importance weights using softmax
+- Returns both selected features and their weights
+- Supports different input dimensions for each feature
+
+## Usage in Preprocessing Model
+
+### Configuration
+
+Configure feature selection in your preprocessing model:
+
+```python
+model = PreprocessingModel(
+    # ... other parameters ...
+    feature_selection_placement="all_features",  # or "numeric" or "categorical"
+    feature_selection_units=64,
+    feature_selection_dropout=0.2
+)
+```
+
+### Placement Options
+
+The `FeatureSelectionPlacementOptions` enum provides several options for where to apply feature selection:
+
+1. `NONE`: Disable feature selection
+2. `NUMERIC`: Apply only to numeric features
+3. `CATEGORICAL`: Apply only to categorical features
+4. `ALL_FEATURES`: Apply to all features
+
+### Accessing Feature Weights
+
+After processing, feature weights are available in the `processed_features` dictionary:
+
+```python
+# Process your data
+processed = model.transform(data)
+
+# Access feature weights
+numeric_weights = processed["numeric_feature_weights"]
+categorical_weights = processed["categorical_feature_weights"]
+```
+
+## Benefits
+
+1. **Automatic Feature Selection**: The model learns which features are most important for your task.
+2. **Interpretability**: Feature weights provide insights into feature importance.
+3. **Improved Performance**: By focusing on relevant features, the model can achieve better performance.
+4. **Regularization**: Dropout and residual connections help prevent overfitting.
+5. **Flexibility**: Can be applied to different feature types and combinations.
+
+## Integration with Other Features
+
+The feature selection mechanism integrates seamlessly with other preprocessing components:
+
+1. **Transformer Blocks**: Can be used before or after transformer blocks
+2. **Tabular Attention**: Complements tabular attention by focusing on important features
+3. **Custom Preprocessors**: Works with any custom preprocessing steps
+
+## Example
+
+Here's a complete example of using feature selection:
+
+```python
+from kdp.processor import PreprocessingModel
+from kdp.features import NumericalFeature, CategoricalFeature
+
+# Define features
+features = {
+    "numeric_1": NumericalFeature("numeric_1"),
+    "numeric_2": NumericalFeature("numeric_2"),
+    "category_1": CategoricalFeature("category_1"),
+}
+
+# Create model with feature selection
+model = PreprocessingModel(
+    features_specs=features,
+    feature_selection_placement="all_features",
+    feature_selection_units=64,
+    feature_selection_dropout=0.2
+)
+
+# Build and use the model
+preprocessor = model.build_preprocessor()
+processed_data = model.transform(data)
+
+# Analyze feature importance
+for feature_name in features:
+    weights = processed_data[f"{feature_name}_weights"]
+    print(f"Feature {feature_name} importance: {weights.mean()}")
+```
+
+## Testing
+
+The feature selection components include comprehensive unit tests that verify:
+
+1. Output shapes and types
+2. Gating mechanism behavior
+3. Residual connections
+4. Dropout behavior
+5. Feature weight properties
+6. Serialization/deserialization
+
+Run the tests using:
+```bash
+python -m pytest test/test_feature_selection.py -v
+```

--- a/kdp/custom_layers.py
+++ b/kdp/custom_layers.py
@@ -761,3 +761,244 @@ class MultiResolutionTabularAttention(tf.keras.layers.Layer):
             MultiResolutionTabularAttention: A new instance of the layer
         """
         return cls(**config)
+
+
+class GatedLinearUnit(tf.keras.layers.Layer):
+    """GatedLinearUnit is a custom Keras layer that implements a gated linear unit.
+
+    This layer applies a dense linear transformation to the input tensor and multiplies the result with the output
+    of a dense sigmoid transformation. The result is a tensor where the input data is filtered based on the learned
+    weights and biases of the layer.
+
+    Args:
+        units (int): Positive integer, dimensionality of the output space.
+
+    Returns:
+        tf.Tensor: Output tensor of the GatedLinearUnit layer.
+    """
+
+    def __init__(self, units: int, **kwargs: dict) -> None:
+        """Initialize the GatedLinearUnit layer.
+
+        Args:
+            units (int): Dimensionality of the output space.
+            **kwargs: Additional keyword arguments passed to the parent class.
+        """
+        super().__init__(**kwargs)
+        self.units = units
+        self.linear = tf.keras.layers.Dense(units)
+        self.sigmoid = tf.keras.layers.Dense(units, activation="sigmoid")
+
+    def call(self, inputs: tf.Tensor) -> tf.Tensor:
+        """Forward pass of the layer.
+
+        Args:
+            inputs (tf.Tensor): Input tensor.
+
+        Returns:
+            tf.Tensor: Output tensor after applying gated linear transformation.
+        """
+        return self.linear(inputs) * self.sigmoid(inputs)
+
+    def get_config(self) -> dict:
+        """Get layer configuration.
+
+        Returns:
+            dict: Layer configuration dictionary.
+        """
+        config = super().get_config()
+        config.update(
+            {
+                "units": self.units,
+            },
+        )
+        return config
+
+    @classmethod
+    def from_config(cls, config: dict) -> "GatedLinearUnit":
+        """Create a layer instance from its config.
+
+        Args:
+            config (dict): Layer configuration dictionary.
+
+        Returns:
+            GatedLinearUnit: A new instance of the layer.
+        """
+        return cls(**config)
+
+
+class GatedResidualNetwork(tf.keras.layers.Layer):
+    """GatedResidualNetwork is a custom Keras layer that implements a gated residual network.
+
+    This layer applies a series of transformations to the input tensor and combines it with the original input
+    using a residual connection. The transformations include a dense layer with ELU activation, a dense linear
+    layer, a dropout layer, a gated linear unit layer, layer normalization, and a final dense layer.
+
+    Args:
+        units (int): Positive integer, dimensionality of the output space.
+        dropout_rate (float): Float between 0 and 1. Fraction of the input units to drop.
+
+    Returns:
+        tf.Tensor: Output tensor of the GatedResidualNetwork layer.
+    """
+
+    def __init__(self, units: int, dropout_rate: float = 0.2, **kwargs: dict) -> None:
+        """Initialize the GatedResidualNetwork layer.
+
+        Args:
+            units (int): Dimensionality of the output space.
+            dropout_rate (float, optional): Fraction of the input units to drop. Defaults to 0.2.
+            **kwargs: Additional keyword arguments passed to the parent class.
+        """
+        super().__init__(**kwargs)
+        self.units = units
+        self.dropout_rate = dropout_rate
+        self.elu_dense = tf.keras.layers.Dense(units, activation="elu")
+        self.linear_dense = tf.keras.layers.Dense(units)
+        self.dropout = tf.keras.layers.Dropout(dropout_rate)
+        self.gated_linear_unit = GatedLinearUnit(units=units)
+        self.layer_norm = tf.keras.layers.LayerNormalization()
+        self.project = tf.keras.layers.Dense(units)
+
+    def call(self, inputs: tf.Tensor, training: bool = False) -> tf.Tensor:
+        """Forward pass of the layer.
+
+        Args:
+            inputs (tf.Tensor): Input tensor.
+            training (bool, optional): Whether in training mode. Defaults to False.
+
+        Returns:
+            tf.Tensor: Output tensor after applying gated residual transformations.
+        """
+        x = self.elu_dense(inputs)
+        x = self.linear_dense(x)
+        x = self.dropout(x, training=training)
+        if inputs.shape[-1] != self.units:
+            inputs = self.project(inputs)
+        x = inputs + self.gated_linear_unit(x)
+        x = self.layer_norm(x)
+        return x
+
+    def get_config(self) -> dict:
+        """Get layer configuration.
+
+        Returns:
+            dict: Layer configuration dictionary.
+        """
+        config = super().get_config()
+        config.update(
+            {
+                "units": self.units,
+                "dropout_rate": self.dropout_rate,
+            },
+        )
+        return config
+
+    @classmethod
+    def from_config(cls, config: dict) -> "GatedResidualNetwork":
+        """Create a layer instance from its config.
+
+        Args:
+            config (dict): Layer configuration dictionary.
+
+        Returns:
+            GatedResidualNetwork: A new instance of the layer.
+        """
+        return cls(**config)
+
+
+class VariableSelection(tf.keras.layers.Layer):
+    """VariableSelection is a custom Keras layer that implements a variable selection mechanism.
+
+    This layer applies a gated residual network to each feature independently and concatenates the results.
+    It then applies another gated residual network to the concatenated tensor and uses a softmax layer to
+    calculate the weights for each feature. Finally, it combines the weighted features using matrix multiplication.
+
+    Args:
+        nr_features (int): Positive integer, number of input features.
+        units (int): Positive integer, dimensionality of the output space.
+        dropout_rate (float): Float between 0 and 1. Fraction of the input units to drop.
+
+    Returns:
+        tuple[tf.Tensor, tf.Tensor]: A tuple containing:
+            - selected_features: Output tensor after feature selection
+            - feature_weights: Weights assigned to each feature
+    """
+
+    def __init__(self, nr_features: int, units: int, dropout_rate: float = 0.2, **kwargs: dict) -> None:
+        """Initialize the VariableSelection layer.
+
+        Args:
+            nr_features (int): Number of input features.
+            units (int): Dimensionality of the output space.
+            dropout_rate (float, optional): Fraction of the input units to drop. Defaults to 0.2.
+            **kwargs: Additional keyword arguments passed to the parent class.
+        """
+        super().__init__(**kwargs)
+        self.nr_features = nr_features
+        self.units = units
+        self.dropout_rate = dropout_rate
+
+        self.grns = []
+        # Create a GRN for each feature independently
+        for _ in range(nr_features):
+            grn = GatedResidualNetwork(units=units, dropout_rate=dropout_rate)
+            self.grns.append(grn)
+
+        # Create a GRN for the concatenation of all the features
+        self.grn_concat = GatedResidualNetwork(units=units, dropout_rate=dropout_rate)
+        self.softmax = tf.keras.layers.Dense(units=nr_features, activation="softmax")
+
+    def call(self, inputs: list[tf.Tensor], training: bool = False) -> tuple[tf.Tensor, tf.Tensor]:
+        """Forward pass of the layer.
+
+        Args:
+            inputs (list[tf.Tensor]): List of input tensors.
+            training (bool, optional): Whether in training mode. Defaults to False.
+
+        Returns:
+            tuple[tf.Tensor, tf.Tensor]: Tuple containing selected features and feature weights.
+        """
+        # Process concatenated features
+        v = tf.keras.layers.concatenate(inputs)
+        v = self.grn_concat(v, training=training)
+        feature_weights = self.softmax(v)
+        feature_weights = tf.expand_dims(feature_weights, axis=-1)
+
+        # Process each feature independently
+        x = []
+        for idx, feature_input in enumerate(inputs):
+            x.append(self.grns[idx](feature_input, training=training))
+        x = tf.stack(x, axis=1)
+
+        # Apply feature selection weights
+        selected_features = tf.squeeze(tf.matmul(feature_weights, x, transpose_a=True), axis=1)
+        return selected_features, feature_weights
+
+    def get_config(self) -> dict:
+        """Get layer configuration.
+
+        Returns:
+            dict: Layer configuration dictionary.
+        """
+        config = super().get_config()
+        config.update(
+            {
+                "nr_features": self.nr_features,
+                "units": self.units,
+                "dropout_rate": self.dropout_rate,
+            },
+        )
+        return config
+
+    @classmethod
+    def from_config(cls, config: dict) -> "VariableSelection":
+        """Create a layer instance from its config.
+
+        Args:
+            config (dict): Layer configuration dictionary.
+
+        Returns:
+            VariableSelection: A new instance of the layer.
+        """
+        return cls(**config)

--- a/kdp/layers_factory.py
+++ b/kdp/layers_factory.py
@@ -2,6 +2,7 @@ import inspect
 
 import tensorflow as tf
 
+from kdp.custom_layers import VariableSelection  # Add VariableSelection to the import list
 from kdp.custom_layers import (
     CastToFloat32Layer,
     DateEncodingLayer,
@@ -197,6 +198,23 @@ class PreprocessorLayerFactory:
             num_heads=num_heads,
             d_model=d_model,
             embedding_dim=embedding_dim,
+            name=name,
+            **kwargs,
+        )
+
+    @staticmethod
+    def variable_selection_layer(name: str = "variable_selection", **kwargs: dict) -> tf.keras.layers.Layer:
+        """Create a VariableSelection layer.
+
+        Args:
+            name: The name of the layer.
+            **kwargs: Additional keyword arguments to pass to the layer constructor.
+
+        Returns:
+            An instance of the VariableSelection layer.
+        """
+        return PreprocessorLayerFactory.create_layer(
+            layer_class=VariableSelection,
             name=name,
             **kwargs,
         )

--- a/test/test_feature_selection.py
+++ b/test/test_feature_selection.py
@@ -1,0 +1,150 @@
+"""Unit tests for feature selection layers."""
+
+import numpy as np
+import tensorflow as tf
+
+from kdp.custom_layers import GatedLinearUnit, GatedResidualNetwork, VariableSelection
+
+
+class TestGatedLinearUnit(tf.test.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.batch_size = 32
+        self.input_dim = 100
+        self.units = 64
+        self.layer = GatedLinearUnit(units=self.units)
+
+    def test_output_shape(self):
+        inputs = tf.random.normal((self.batch_size, self.input_dim))
+        outputs = self.layer(inputs)
+        self.assertEqual(outputs.shape, (self.batch_size, self.units))
+
+    def test_gating_mechanism(self):
+        # Test that outputs are bounded by the sigmoid gate
+        inputs = tf.random.normal((self.batch_size, self.input_dim))
+        outputs = self.layer(inputs)
+        self.assertAllInRange(outputs, -10.0, 10.0)  # Reasonable range for gated outputs
+
+    def test_serialization(self):
+        config = self.layer.get_config()
+        new_layer = GatedLinearUnit.from_config(config)
+        self.assertEqual(self.layer.units, new_layer.units)
+
+
+class TestGatedResidualNetwork(tf.test.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.batch_size = 32
+        self.input_dim = 100
+        self.units = 64
+        self.dropout_rate = 0.2
+        self.layer = GatedResidualNetwork(units=self.units, dropout_rate=self.dropout_rate)
+
+    def test_output_shape(self):
+        inputs = tf.random.normal((self.batch_size, self.input_dim))
+        outputs = self.layer(inputs)
+        self.assertEqual(outputs.shape, (self.batch_size, self.units))
+
+    def test_residual_connection(self):
+        # Test that the layer can handle different input dimensions
+        inputs = tf.random.normal((self.batch_size, self.input_dim))
+        outputs = self.layer(inputs)
+        self.assertEqual(outputs.shape[-1], self.units)
+
+        # Test with matching dimensions
+        inputs = tf.random.normal((self.batch_size, self.units))
+        outputs = self.layer(inputs)
+        self.assertEqual(outputs.shape, inputs.shape)
+
+    def test_dropout_behavior(self):
+        inputs = tf.random.normal((self.batch_size, self.input_dim))
+
+        # Test training phase (dropout active)
+        training_outputs = []
+        for _ in range(5):
+            outputs = self.layer(inputs, training=True)
+            training_outputs.append(outputs)
+
+        # Outputs should be different during training due to dropout
+        for i in range(len(training_outputs) - 1):
+            self.assertNotAllClose(training_outputs[i], training_outputs[i + 1])
+
+        # Test inference phase (dropout inactive)
+        inference_outputs = []
+        for _ in range(5):
+            outputs = self.layer(inputs, training=False)
+            inference_outputs.append(outputs)
+
+        # Outputs should be identical during inference
+        for i in range(len(inference_outputs) - 1):
+            self.assertAllClose(inference_outputs[i], inference_outputs[i + 1])
+
+    def test_serialization(self):
+        config = self.layer.get_config()
+        new_layer = GatedResidualNetwork.from_config(config)
+        self.assertEqual(self.layer.units, new_layer.units)
+        self.assertEqual(self.layer.dropout_rate, new_layer.dropout_rate)
+
+
+class TestVariableSelection(tf.test.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.batch_size = 32
+        self.nr_features = 3
+        self.feature_dims = [100, 200, 300]  # Different dimensions for each feature
+        self.units = 64
+        self.dropout_rate = 0.2
+        self.layer = VariableSelection(nr_features=self.nr_features, units=self.units, dropout_rate=self.dropout_rate)
+
+    def test_output_shape(self):
+        # Create inputs with different dimensions
+        inputs = [tf.random.normal((self.batch_size, dim)) for dim in self.feature_dims]
+
+        outputs, weights = self.layer(inputs)
+
+        # Check output shapes
+        self.assertEqual(outputs.shape, (self.batch_size, self.units))
+        self.assertEqual(weights.shape, (self.batch_size, self.nr_features, 1))
+
+    def test_feature_weights(self):
+        inputs = [tf.random.normal((self.batch_size, dim)) for dim in self.feature_dims]
+
+        _, weights = self.layer(inputs)
+        weights = tf.squeeze(weights, axis=-1)
+
+        # Check that weights sum to 1 for each sample
+        weights_sum = tf.reduce_sum(weights, axis=-1)
+        self.assertAllClose(weights_sum, tf.ones_like(weights_sum))
+
+        # Check that weights are non-negative
+        self.assertAllGreaterEqual(weights, 0.0)
+
+    def test_dropout_behavior(self):
+        inputs = [tf.random.normal((self.batch_size, dim)) for dim in self.feature_dims]
+
+        # Test training phase (dropout active)
+        training_outputs = []
+        for _ in range(5):
+            outputs, _ = self.layer(inputs, training=True)
+            training_outputs.append(outputs)
+
+        # Outputs should be different during training due to dropout
+        for i in range(len(training_outputs) - 1):
+            self.assertNotAllClose(training_outputs[i], training_outputs[i + 1])
+
+        # Test inference phase (dropout inactive)
+        inference_outputs = []
+        for _ in range(5):
+            outputs, _ = self.layer(inputs, training=False)
+            inference_outputs.append(outputs)
+
+        # Outputs should be identical during inference
+        for i in range(len(inference_outputs) - 1):
+            self.assertAllClose(inference_outputs[i], inference_outputs[i + 1])
+
+    def test_serialization(self):
+        config = self.layer.get_config()
+        new_layer = VariableSelection.from_config(config)
+        self.assertEqual(self.layer.nr_features, new_layer.nr_features)
+        self.assertEqual(self.layer.units, new_layer.units)
+        self.assertEqual(self.layer.dropout_rate, new_layer.dropout_rate)


### PR DESCRIPTION
This pull request introduces a new feature selection mechanism to the Keras Data Processor, leveraging the Gated Residual Variable Selection Network (GRVSN) architecture. The changes include comprehensive documentation, new custom layers, and integration into the preprocessing model. Below are the most important changes:

### Documentation:
* [`docs/feature_selection.md`](diffhunk://#diff-515e49eb9b495d4ab325ba65bb89877994825cc3add2ad51f1a9af49f128d051R1-R160): Added a detailed explanation of the new feature selection mechanism, including components, usage, benefits, and examples.

### New Custom Layers:
* [`kdp/custom_layers.py`](diffhunk://#diff-13efa75d1ce45b4fc672fa1f45c3c554d2afea06f6110848662c8d9fa78c3698R764-R1004): Added three new custom Keras layers: `GatedLinearUnit`, `GatedResidualNetwork`, and `VariableSelection`, each with detailed docstrings and configuration methods.

### Integration:
* [`kdp/layers_factory.py`](diffhunk://#diff-17dc8ca2ecbd33408e9935a98157ef8ed3a69c28bb6b86a3a91c9014db14d643R5): Added `VariableSelection` to the import list and created a static method to instantiate the `VariableSelection` layer. [[1]](diffhunk://#diff-17dc8ca2ecbd33408e9935a98157ef8ed3a69c28bb6b86a3a91c9014db14d643R5) [[2]](diffhunk://#diff-17dc8ca2ecbd33408e9935a98157ef8ed3a69c28bb6b86a3a91c9014db14d643R204-R220)
* [`kdp/processor.py`](diffhunk://#diff-0269f36854f3d7eb0fd3537a04e877a0fa80a0048a1f7184edf494e88d8e57c6R60-R68): Introduced the `FeatureSelectionPlacementOptions` enum and added parameters for feature selection in the preprocessing model's initialization. Modified the `_add_pipeline_numeric` and `_add_pipeline_categorical` methods to apply feature selection if enabled. [[1]](diffhunk://#diff-0269f36854f3d7eb0fd3537a04e877a0fa80a0048a1f7184edf494e88d8e57c6R60-R68) [[2]](diffhunk://#diff-0269f36854f3d7eb0fd3537a04e877a0fa80a0048a1f7184edf494e88d8e57c6R164-R166) [[3]](diffhunk://#diff-0269f36854f3d7eb0fd3537a04e877a0fa80a0048a1f7184edf494e88d8e57c6R195-R197) [[4]](diffhunk://#diff-0269f36854f3d7eb0fd3537a04e877a0fa80a0048a1f7184edf494e88d8e57c6R224-R228) [[5]](diffhunk://#diff-0269f36854f3d7eb0fd3537a04e877a0fa80a0048a1f7184edf494e88d8e57c6L580-R613) [[6]](diffhunk://#diff-0269f36854f3d7eb0fd3537a04e877a0fa80a0048a1f7184edf494e88d8e57c6R697-R711)…k capability